### PR TITLE
Add slottable notification framework

### DIFF
--- a/notifications/NotificationManager.m
+++ b/notifications/NotificationManager.m
@@ -1,0 +1,89 @@
+classdef NotificationManager < handle
+    % NotificationManager  Registry + fault-tolerant broadcast for Notifiers.
+    %
+    % Holds a heterogeneous array of Notifier objects and fans a message out
+    % to every enabled one. A notifier that errors only warns -- a failed
+    % notification must never crash or block an experiment.
+    %
+    % Mirrors the slottable-module pattern of ModuleManager, but with a plain
+    % Notifier array (matlab.mixin.Heterogeneous) rather than dynamicprops,
+    % since notifiers are looked up by their .name field, not as properties.
+    %
+    % See also Notifier, WebhookNotifier, ModuleManager.
+
+    properties
+        notifiers = Notifier.empty;
+    end
+
+    methods
+        function obj = NotificationManager()
+        end
+
+        function add(obj, notifier)
+            obj.notifiers(end+1) = notifier;
+        end
+
+        function notify(obj, subject, body, meta)
+            % Broadcast to every enabled notifier. Each send is isolated in a
+            % try/catch so one bad channel can't take down the others (or the
+            % experiment). meta is optional context passed through to send().
+            if nargin < 3, body = ''; end
+            if nargin < 4, meta = struct(); end
+            for k = 1:numel(obj.notifiers)
+                n = obj.notifiers(k);
+                if ~n.enabled
+                    continue
+                end
+                try
+                    n.send(subject, body, meta);
+                catch ME
+                    warning('NotificationManager:sendFailed', ...
+                        'Notifier "%s" failed: %s', obj.label(n), ME.message);
+                end
+            end
+        end
+
+        function enable(obj, name)
+            obj.set_enabled(name, true);
+        end
+
+        function disable(obj, name)
+            obj.set_enabled(name, false);
+        end
+
+        function list(obj)
+            % Print the registered notifiers and their state.
+            if isempty(obj.notifiers)
+                fprintf('No notifiers registered.\n');
+                return
+            end
+            for k = 1:numel(obj.notifiers)
+                n = obj.notifiers(k);
+                state = 'disabled';
+                if n.enabled, state = 'enabled'; end
+                fprintf('  [%s] %s (%s)\n', state, obj.label(n), class(n));
+            end
+        end
+    end
+
+    methods (Access = private)
+        function set_enabled(obj, name, tf)
+            hit = false;
+            for k = 1:numel(obj.notifiers)
+                if strcmp(obj.notifiers(k).name, name)
+                    obj.notifiers(k).enabled = tf;
+                    hit = true;
+                end
+            end
+            if ~hit
+                warning('NotificationManager:noSuchNotifier', ...
+                    'No notifier named "%s".', name);
+            end
+        end
+
+        function s = label(~, n)
+            s = n.name;
+            if isempty(s), s = class(n); end
+        end
+    end
+end

--- a/notifications/WebhookNotifier.m
+++ b/notifications/WebhookNotifier.m
@@ -1,0 +1,65 @@
+classdef WebhookNotifier < Notifier
+    % WebhookNotifier  Post a notification to a Slack or Discord webhook.
+    %
+    % Delivery is a single HTTP POST via stock MATLAB webwrite (no toolbox),
+    % mirroring holodaq's RESTio. The webhook URL is passed in directly so the
+    % framework stays free of any pref/secret handling -- callers supply the
+    % URL (e.g. read from getpref in the scope2k wiring layer).
+    %
+    %   n = WebhookNotifier(url, 'slack');            % or 'discord'
+    %   n.send('Run finished', 'mouse123 / epoch2 done');
+    %
+    % See also Notifier, NotificationManager, RESTio.
+
+    properties
+        url
+        platform = 'slack';   % 'slack' | 'discord'
+        timeout  = 5;         % seconds; short so a slow network never stalls
+    end
+
+    methods
+        function obj = WebhookNotifier(url, platform, name)
+            if nargin < 2 || isempty(platform), platform = 'slack'; end
+            if nargin < 3 || isempty(name), name = sprintf('webhook-%s', platform); end
+            obj@Notifier(name);
+            obj.url = url;
+            obj.platform = lower(platform);
+        end
+
+        function send(obj, subject, body, meta)
+            if nargin < 3, body = ''; end
+            if nargin < 4, meta = struct(); end %#ok<NASGU>  % reserved for richer payloads
+            if isempty(obj.url)
+                error('WebhookNotifier:noUrl', 'No webhook URL configured.');
+            end
+
+            text = obj.format(subject, body);
+            payload = obj.build_payload(text);
+            ops = weboptions('MediaType', 'application/json', 'Timeout', obj.timeout);
+            webwrite(obj.url, payload, ops);
+        end
+    end
+
+    methods (Access = private)
+        function text = format(~, subject, body)
+            if isempty(body)
+                text = subject;
+            else
+                text = sprintf('*%s*\n%s', subject, body);
+            end
+        end
+
+        function payload = build_payload(obj, text)
+            % Slack expects {"text": ...}; Discord expects {"content": ...}.
+            switch obj.platform
+                case 'slack'
+                    payload = struct('text', text);
+                case 'discord'
+                    payload = struct('content', text);
+                otherwise
+                    error('WebhookNotifier:badPlatform', ...
+                        'Unknown platform "%s" (use slack or discord).', obj.platform);
+            end
+        end
+    end
+end

--- a/notifications/abs/Notifier.m
+++ b/notifications/abs/Notifier.m
@@ -1,0 +1,29 @@
+classdef Notifier < matlab.mixin.Heterogeneous & handle
+    % Notifier  Abstract base for a slottable notification channel.
+    %
+    % A Notifier is a self-contained delivery channel (Slack/Discord webhook,
+    % email, SMS, ...) that a NotificationManager can broadcast to. Subclasses
+    % override send() with their transport. Keep transport logic in the
+    % subclass; this base only defines the interface and the enabled flag.
+    %
+    % See also NotificationManager, WebhookNotifier, Module.
+
+    properties
+        enabled = true;   % skipped by NotificationManager when false
+        name    = '';     % human-readable label, used for enable/disable lookup
+    end
+
+    methods
+        function obj = Notifier(name)
+            if nargin >= 1 && ~isempty(name)
+                obj.name = name;
+            end
+        end
+
+        function send(obj, subject, body, meta)
+            % Overwritten in subclass. subject/body are char; meta is an
+            % optional struct of context (mouse, epoch, experiment, trial...).
+            % No-op here so an un-overridden notifier is harmless.
+        end
+    end
+end


### PR DESCRIPTION
## What

Adds a reusable, slottable notification subsystem under `notifications/`, mirroring the existing `ModuleManager`/`Module` plugin pattern.

- **`Notifier`** (`notifications/abs/Notifier.m`) — abstract base (`matlab.mixin.Heterogeneous & handle`) with an `enabled` flag and a no-op `send()` that subclasses override.
- **`NotificationManager`** (`notifications/NotificationManager.m`) — registry + fault-tolerant broadcast. Each `send()` is isolated in `try/catch`, so a failing channel only warns and can never crash or block an experiment. Supports `enable`/`disable`/`list` by name.
- **`WebhookNotifier`** (`notifications/WebhookNotifier.m`) — concrete Slack/Discord channel that POSTs via stock MATLAB `webwrite` (no toolbox), with a short timeout. The URL is passed in by the caller so this framework stays free of any secret/pref handling.

## Why

Long experiments give no signal when you've stepped away from the rig. This is the reusable half of a notification feature; the scope2k-experiments side wires these onto `Experiment` events (`RunFinished`, `TrialCompleted`) and reads the webhook URL from per-machine prefs. Email/SMS channels can be added later by subclassing `Notifier` — no manager changes needed.

## Testing

Exercised headlessly in MATLAB R2023b (`mlint` clean; functional harness):
- broadcast to enabled notifiers, skip disabled, re-enable
- a deliberately-throwing notifier only warns (fault tolerance), never crashes
- Slack + Discord payload construction via `webwrite`
- idle/no-op behavior when no notifier is registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)